### PR TITLE
Update order of php-parser loading

### DIFF
--- a/templates/phpstan/bootstrap.php
+++ b/templates/phpstan/bootstrap.php
@@ -21,22 +21,22 @@ require_once $rootDir . '/config/bootstrap.php';
 
 // Make sure loader php-parser is coming from php stan composer
 
-// 1- Use with Docker container
+// 1- Use module vendors
+$loader = new \Composer\Autoload\ClassLoader();
+$loader->setPsr4('PhpParser\\', ['vendor/nikic/php-parser/lib/PhpParser']);
+$loader->register(true);
+// 2- Use with Docker container
 $loader = new \Composer\Autoload\ClassLoader();
 $loader->setPsr4('PhpParser\\', ['/composer/vendor/nikic/php-parser/lib/PhpParser']);
 $loader->register(true);
-// 2- Use with PHPStan phar
+// 3- Use with PHPStan phar
 $loader = new \Composer\Autoload\ClassLoader();
 // Contains the vendor in phar, like "phar://phpstan.phar/vendor"
 $loader->setPsr4('PhpParser\\', ['phar://' . dirname($_SERVER['PATH_TRANSLATED']) . '/../phpstan/phpstan-shim/phpstan.phar/vendor/nikic/php-parser/lib/PhpParser/']);
 $loader->register(true);
-// 3- Use phpstan phar with sym link
+// 4- Use phpstan phar with sym link
 $loader = new \Composer\Autoload\ClassLoader();
 $loader->setPsr4('PhpParser\\', ['phar://' . realpath($_SERVER['PATH_TRANSLATED']) . '/vendor/nikic/php-parser/lib/PhpParser/']);
-$loader->register(true);
-// 4 - Use module vendors
-$loader = new \Composer\Autoload\ClassLoader();
-$loader->setPsr4('PhpParser\\', ['vendor/nikic/php-parser/lib/PhpParser']);
 $loader->register(true);
 
 // We must declare these constant in this boostrap script.


### PR DESCRIPTION
When integrating header-stamp in this project, php-parser has been included at the same time, breaking all run of phpstan.

This was caused by the php-parser lib from the module loaded at the end which took the first position in the autoloaders list. This change allows PhpStan PHAR to get the priority.