### PR TITLE
Add an error formatter for GitHub actions annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@ It'll create a configuration file `.php_cs.dist` in the root of your project.
 $ php vendor/bin/prestashop-coding-standards phpstan:init [--dest /path/to/my/project]
 ```
 
-It'll create a `bootstrap.php` and a `phpstan.neon` files, by default in `tests/phpstan`, that are required to run phpstan.
+It'll create a default file `phpstan.neon` in `tests/phpstan`, that are required to run phpstan.
 The default phpstan level is the lowest available, but we recommend you to update this value to get more recommandations.
 
 PHPStan is not provided by our dependencies, because of the PHP compatibility from projects using this repository. We recommend you to install it globally on your environment:
 
 ```
-composer global require phpstan/phpstan-shim
+composer global require phpstan/phpstan:^0.12
 ```
 
 ## Usage
@@ -65,6 +65,12 @@ Otherwise, you can specify the path to the PHPStan binary. For instance:
 ```php
 $ _PS_ROOT_DIR_=<Path_to_PrestaShop> php ~/.composer/vendor/bin/phpstan.phar --configuration=tests/phpstan/phpstan.neon analyse <path1 [path2 [...]]>
 ```
+
+If GitHub Actions are used to run PHPStan, an additional error formater allows feedback to be added as annotations in pull-requests diff:
+
+![Report with annotation](https://user-images.githubusercontent.com/6768917/82919118-82a00c00-9f6d-11ea-8519-267aad6897d4.png)
+
+Add `--error-format github` at the end of the command to use it.
 
 ### Header Stamp
 

--- a/phpstan/ps-module-extension.neon
+++ b/phpstan/ps-module-extension.neon
@@ -2,3 +2,10 @@ parameters:
   bootstrap: %currentWorkingDirectory%/vendor/prestashop/php-dev-tools/phpstan/bootstrap.php
   dynamicConstantNames:
     - _PS_VERSION_
+
+services:
+  errorFormatter.github:
+    class: PrestaShop\CodingStandards\ErrorFormatter\GithubErrorFormatter
+    arguments:
+      relativePathHelper: @simpleRelativePathHelper
+      showTipsOfTheDay: %tipsOfTheDay%

--- a/src/ErrorFormatter/GithubErrorFormatter.php
+++ b/src/ErrorFormatter/GithubErrorFormatter.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types = 1);
+
+namespace PrestaShop\CodingStandards\ErrorFormatter;
+
+use PHPStan\Command\AnalysisResult;
+use PHPStan\Command\ErrorFormatter\TableErrorFormatter;
+use PHPStan\Command\Output;
+use PHPStan\File\RelativePathHelper;
+
+class GithubErrorFormatter extends TableErrorFormatter
+{
+
+	private RelativePathHelper $relativePathHelper;
+
+	public function __construct(
+		RelativePathHelper $relativePathHelper,
+		bool $showTipsOfTheDay
+	)
+	{
+		parent::__construct($relativePathHelper, $showTipsOfTheDay);
+		$this->relativePathHelper = $relativePathHelper;
+	}
+
+	public function formatErrors(AnalysisResult $analysisResult, Output $output): int
+	{
+		parent::formatErrors($analysisResult, $output);
+
+		foreach ($analysisResult->getFileSpecificErrors() as $fileSpecificError) {
+			$metas = [
+				'file' => $this->relativePathHelper->getRelativePath($fileSpecificError->getFile()),
+				'line' => $fileSpecificError->getLine(),
+				'col' => 0,
+			];
+			array_walk($metas, static function (&$value, string $key): void {
+				$value = sprintf('%s=%s', $key, (string) $value);
+			});
+
+			$severity = $fileSpecificError->canBeIgnored() ? 'warning' : 'error';
+			$message = $fileSpecificError->getMessage();
+
+			$line = sprintf('::%s %s::%s', $severity, implode(',', $metas), $message);
+
+			$output->writeRaw($line);
+			$output->writeLineFormatted('');
+		}
+
+		return $analysisResult->hasErrors() ? 1 : 0;
+	}
+
+	private function formatForGitHubActionAnnotation(string $message): string
+	{
+		return str_replace(["\n", "\r"], ['%0A', '%0D'], $message);
+	}
+}


### PR DESCRIPTION
This PR adds an error formatter for PHPStan. It makes errors displayed in the pull-request diff as annotations, which facilitate access to the report and may avoid redundant checks. 

![image](https://user-images.githubusercontent.com/6768917/82919118-82a00c00-9f6d-11ea-8519-267aad6897d4.png)
 