### PR TITLE
Use bootstrapFiles in phpstan config

### DIFF
--- a/phpstan/ps-module-extension.neon
+++ b/phpstan/ps-module-extension.neon
@@ -1,4 +1,5 @@
 parameters:
-  bootstrap: %currentWorkingDirectory%/vendor/prestashop/php-dev-tools/phpstan/bootstrap.php
+  bootstrapFiles:
+    - %currentWorkingDirectory%/vendor/prestashop/php-dev-tools/phpstan/bootstrap.php
   dynamicConstantNames:
     - _PS_VERSION_


### PR DESCRIPTION
PHPStan has elvoved and requires our configuration file to be updated:
![image](https://user-images.githubusercontent.com/6768917/89054057-76af3c80-d358-11ea-969d-28aed6ea18c9.png)

The changes follows the new documentation