### PR TITLE
Add a stub for module class, allowing developers to not redefine properies in all modules

### DIFF
--- a/phpstan/ps-module-extension.neon
+++ b/phpstan/ps-module-extension.neon
@@ -1,5 +1,7 @@
 parameters:
   bootstrapFiles:
     - %currentWorkingDirectory%/vendor/prestashop/php-dev-tools/phpstan/bootstrap.php
+  stubFiles:
+    - stubs/Module.stub
   dynamicConstantNames:
     - _PS_VERSION_

--- a/phpstan/stubs/Module.stub
+++ b/phpstan/stubs/Module.stub
@@ -1,0 +1,29 @@
+<?php
+
+namespace PrestaShop\PrestaShop\Core\Module {
+    
+    interface ModuleInterface
+    {
+    }
+}
+
+namespace {
+
+    class Module extends ModuleCore
+    {
+    }
+    
+    use PrestaShop\PrestaShop\Core\Module\ModuleInterface;
+    
+    /**
+     * Missing properties:
+     * @property string $module_key 
+     * @property bool $bootstrap 
+     * @property string $confirmUninstall 
+     */
+    abstract class ModuleCore implements ModuleInterface
+    {
+        /** @var string */
+        public $version;
+    }
+}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | All developers must redefine several properties on their module class, because old versions of PrestaShop did not set `bootstrap` & `confirmUninstall`. This PR adds a stub that will prevent false-positive with PHPStan
| Type?         | improvement
| BC breaks?    | Nope
| Deprecations? | Nope
