### PR TITLE
phpstan config : add  _PS_MODE_DEV_ to dynamicConstantNames

### DIFF
--- a/phpstan/ps-module-extension.neon
+++ b/phpstan/ps-module-extension.neon
@@ -5,3 +5,4 @@ parameters:
     - stubs/Module.stub
   dynamicConstantNames:
     - _PS_VERSION_
+    - _PS_MODE_DEV_


### PR DESCRIPTION
to let phpstan understan that this constant can vary.

For example, if a module logs errors depending on the dev_mode
```php
            if (_PS_MODE_DEV_) {
                Logger::AddLog(' blabla ' . $exception->getMessage());
            }
```

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Please be specific when describing the PR. Every detail helps: What are you changing? Why?
| Type?         | bug fix / improvement / new feature / refacto
| BC breaks?    | yes / no
| Deprecations? | yes / no
| Fixed ticket? | Fixes {paste the issue here}.
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
