### PR TITLE
Abort bootstrap if _PS_ROOT_DIR_ is incorrect

### DIFF
--- a/phpstan/bootstrap.php
+++ b/phpstan/bootstrap.php
@@ -19,7 +19,7 @@ if (!$rootDir) {
     exit(1);
 }
 if (!realpath($rootDir)) {
-    echo sprintf("[ERROR] _PS_ROOT_DIR_ configuration is wrong. No directory found at %s .", $rootDir) . PHP_EOL;
+    echo sprintf('[ERROR] _PS_ROOT_DIR_ configuration is wrong. No directory found at %s .', $rootDir) . PHP_EOL;
     exit(1);
 }
 

--- a/phpstan/bootstrap.php
+++ b/phpstan/bootstrap.php
@@ -18,7 +18,7 @@ if (!$rootDir) {
     echo '[ERROR] Define _PS_ROOT_DIR_ with the path to PrestaShop folder' . PHP_EOL;
     exit(1);
 }
-if(!realpath($rootDir)) {
+if (!realpath($rootDir)) {
     echo sprintf("[ERROR] _PS_ROOT_DIR_ configuration is wrong. No directory found at %s .", $rootDir) . PHP_EOL;
     exit(1);
 }

--- a/phpstan/bootstrap.php
+++ b/phpstan/bootstrap.php
@@ -18,6 +18,10 @@ if (!$rootDir) {
     echo '[ERROR] Define _PS_ROOT_DIR_ with the path to PrestaShop folder' . PHP_EOL;
     exit(1);
 }
+if(!realpath($rootDir)) {
+    echo sprintf("[ERROR] _PS_ROOT_DIR_ configuration is wrong. No directory found at %s .", $rootDir) . PHP_EOL;
+    exit(1);
+}
 
 // This file will be in the directory vendor/prestashop/php-dev-tools/phpstan.
 $pathToModuleRoot = __DIR__ . '/../../../../';


### PR DESCRIPTION
As previous check, may help with configuration.

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Abort bootstrap if _PS_ROOT_DIR_ is incorrect
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | nop
| How to test?  | run a phpstan with a wrong _PS_ROOT_DIR_ env variable.
