### PR TITLE
Correct return value for init command

### DIFF
--- a/src/Command/CsFixerInitCommand.php
+++ b/src/Command/CsFixerInitCommand.php
@@ -37,6 +37,6 @@ class CsFixerInitCommand extends AbstractCommand
             );
         }
 
-        return self::SUCCESS;
+        return 0;
     }
 }

--- a/src/Command/CsFixerInitCommand.php
+++ b/src/Command/CsFixerInitCommand.php
@@ -36,5 +36,7 @@ class CsFixerInitCommand extends AbstractCommand
                 $destination . '/.' . $template
             );
         }
+
+        return self::SUCCESS;
     }
 }

--- a/src/Command/PhpStanInitCommand.php
+++ b/src/Command/PhpStanInitCommand.php
@@ -37,6 +37,6 @@ class PhpStanInitCommand extends AbstractCommand
             );
         }
 
-        return self::SUCCESS;
+        return 0;
     }
 }

--- a/src/Command/PhpStanInitCommand.php
+++ b/src/Command/PhpStanInitCommand.php
@@ -36,5 +36,7 @@ class PhpStanInitCommand extends AbstractCommand
                 $destination . '/' . $template
             );
         }
+
+        return self::SUCCESS;
     }
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | This correct a type error when running the phpstan init command
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| How to test?  | Please indicate how to best verify that this PR is correct.

```
PHP Fatal error:  Uncaught TypeError: Return value of "PrestaShop\CodingStandards\Command\PhpStanInitCommand::execute()" must be of the type int, "null" returned. in vendor/symfony/console/Command/Command.php:258
Stack trace:
#0 vendor/symfony/console/Application.php(971): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#1 vendor/symfony/console/Application.php(290): Symfony\Component\Console\Application->doRunCommand(Object(PrestaShop\CodingStandards\Command\PhpStanInitCommand), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#2 vendor/symfony/console/Application.php(166): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component in vendor/symfony/console/Command/Command.php on line 258
```