### PR TITLE
Add stub for Module::getInstanceByName always returning true

### DIFF
--- a/phpstan/stubs/Module.stub
+++ b/phpstan/stubs/Module.stub
@@ -25,5 +25,15 @@ namespace {
     {
         /** @var string */
         public $version;
+
+        /**
+         * Return type was wrong until 1.7.7.0
+         * https://github.com/PrestaShop/PrestaShop/commit/9a8144a15d21e3fdcde3e2a703de3339be6e8295
+         *
+         * @param string $module_name Module name
+         *
+         * @return Module|false
+         */
+        public static function getInstanceByName($module_name) {}
     }
 }


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fix one error reported by phpstan with old versions of PrestaShop about Module::getInstanceByName. It has been fixed on 1.7.7.0 by @Matt75 on https://github.com/PrestaShop/PrestaShop/commit/9a8144a15d21e3fdcde3e2a703de3339be6e8295 but still appears on previous versions.
| Type?             | improvement
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| How to test?      | Run PHPStan on PS < 1.7.7.0 with a module testing the result of Module::getInstanceByName
| Possible impacts? | /

### Issue fixed

```
 ------ ------------------------------------------------------------------ 
  Line   controllers/admin/AdminPsfacebookModuleController.php             
 ------ ------------------------------------------------------------------ 
  286    Strict comparison using === between false and Module will always  
         evaluate to false.                                                
 ------ ------------------------------------------------------------------ 

 [ERROR] Found 1 error   
```
