### PR TITLE
Update PHP CS Fixer github action to use standard GA instead of prestashopcorp/github-action-php-cs-fixer

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -20,8 +20,8 @@ jobs:
     name: PHP-CS-Fixer
     runs-on: ubuntu-latest
     strategy:
-        matrix:
-            php: ['7.3', '7.4']
+      matrix:
+        php: ['7.3', '7.4']
     steps:
         -   name: Setup PHP
             uses: shivammathur/setup-php@v2

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -19,9 +19,20 @@ jobs:
   php-cs-fixer:
     name: PHP-CS-Fixer
     runs-on: ubuntu-latest
+    strategy:
+        matrix:
+            php: ['7.3', '7.4']
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2.0.0
+        -   name: Setup PHP
+            uses: shivammathur/setup-php@v2
+            with:
+                php-version: ${{ matrix.php }}
 
-      - name: Run PHP-CS-Fixer
-        uses: prestashopcorp/github-action-php-cs-fixer@master
+        -   name: Checkout
+            uses: actions/checkout@v2
+
+        -   name: Composer Install
+            run: composer install --ansi --prefer-dist --no-interaction --no-progress --quiet
+
+        -   name: Run PHPCSFixer
+            run: ./vendor/bin/php-cs-fixer fix --dry-run --diff

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -34,5 +34,5 @@ jobs:
       - name: Composer Install
         run: composer install --ansi --prefer-dist --no-interaction --no-progress --quiet
 
-        -   name: Run PHPCSFixer
-            run: ./vendor/bin/php-cs-fixer fix --dry-run --diff
+      - name: Run PHP CS Fixer
+        run: ./vendor/bin/php-cs-fixer fix --dry-run --diff

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -23,16 +23,16 @@ jobs:
       matrix:
         php: ['7.3', '7.4']
     steps:
-        -   name: Setup PHP
-            uses: shivammathur/setup-php@v2
-            with:
-                php-version: ${{ matrix.php }}
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
 
-        -   name: Checkout
-            uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
 
-        -   name: Composer Install
-            run: composer install --ansi --prefer-dist --no-interaction --no-progress --quiet
+      - name: Composer Install
+        run: composer install --ansi --prefer-dist --no-interaction --no-progress --quiet
 
         -   name: Run PHPCSFixer
             run: ./vendor/bin/php-cs-fixer fix --dry-run --diff


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | If we rely on `prestashopcorp/github-action-php-cs-fixer@master` the php version is frozen and this adds a layer of maintainance while the equivalent GitHub Action is not so big.<br/><br/>Also this repository should not depend on a PrestaShopCorp repository as it belongs to the OSS organization.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | 
| Possible impacts? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
