### PR TITLE
Update PHP Syntax linter github action to use standard GA instead of prestashop/github-action-php-lint@master

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -6,8 +6,8 @@ jobs:
     name: PHP Syntax check
     runs-on: ubuntu-latest
     strategy:
-        matrix:
-            php: ['7.2', '7.3', '7.4']
+      matrix:
+        php: ['7.2', '7.3', '7.4']
     steps:
         -   name: Checkout
             uses: actions/checkout@v2.0.0

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -9,8 +9,8 @@ jobs:
       matrix:
         php: ['7.2', '7.3', '7.4']
     steps:
-        -   name: Checkout
-            uses: actions/checkout@v2.0.0
+      - name: Checkout
+        uses: actions/checkout@v2.0.0
 
         -   name: PHP Syntax Checker
             run: sh -c "! (find . -type f -name \"*.php\" $1 -exec php -l -n {} \; | grep -v \"No syntax errors detected\")"

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -12,8 +12,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2.0.0
 
-        -   name: PHP Syntax Checker
-            run: sh -c "! (find . -type f -name \"*.php\" $1 -exec php -l -n {} \; | grep -v \"No syntax errors detected\")"
+      - name: PHP Syntax Checker
+        run: sh -c "! (find . -type f -name \"*.php\" $1 -exec php -l -n {} \; | grep -v \"No syntax errors detected\")"
 
   # Check the PHP code follow the coding standards
   php-cs-fixer:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 jobs:
   # Check there is no syntax errors in the project
   php-linter:
-    name:  PHP Syntax check
+    name: PHP Syntax check
     runs-on: ubuntu-latest
     strategy:
         matrix:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -3,17 +3,17 @@ on: [push, pull_request]
 jobs:
   # Check there is no syntax errors in the project
   php-linter:
-    name: PHP Syntax check 7.2|7.3
+    name:  PHP Syntax check
     runs-on: ubuntu-latest
+    strategy:
+        matrix:
+            php: ['7.2', '7.3', '7.4']
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2.0.0
+        -   name: Checkout
+            uses: actions/checkout@v2.0.0
 
-      - name: PHP syntax checker 7.2
-        uses: prestashop/github-action-php-lint/7.2@master
-
-      - name: PHP syntax checker 7.3
-        uses: prestashop/github-action-php-lint/7.3@master
+        -   name: PHP Syntax Checker
+            run: sh -c "! (find . -type f -name \"*.php\" $1 -exec php -l -n {} \; | grep -v \"No syntax errors detected\")"
 
   # Check the PHP code follow the coding standards
   php-cs-fixer:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | If we rely on `prestashop/github-action-php-lint@master` the php version is frozen and this adds a layer of maintainance while the equivalent GitHub Action is not so big.<br/><br/>Also this repository should not depend on a PrestaShopCorp repository as it belongs to the OSS organization.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | 
| Possible impacts? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
