### PR TITLE
Avoid specific version of php-cs-fixer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,9 @@
     "symfony/filesystem": "~3.2 || ~4.0 || ~5.0",
     "prestashop/header-stamp": "^1.0"
   },
+  "conflict": {
+    "friendsofphp/php-cs-fixer": "2.18.3"
+  },
   "bin": ["bin/prestashop-coding-standards"],
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Seen with https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/5537, the version 2.18.3 of php-cs-fixer breaks our pipeline. Let's avoid this version.
| Type?             | bug fix
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | Fixes all PHP pipelines
| How to test?      | /
| Possible impacts? | None