### PR TITLE
Fix wrong filepath

### DIFF
--- a/templates/phpstan/phpstan.neon
+++ b/templates/phpstan/phpstan.neon
@@ -3,6 +3,9 @@ includes:
     
 parameters:
   paths:
+    - ./
+  excludes_analyse:
+    - vendor/
   # We consider that the extension file will be stored the folder test/phpstan
   # From Phpstan 0.12, paths are relative to the .neon file.
   # - ../../classes

--- a/templates/phpstan/phpstan.neon
+++ b/templates/phpstan/phpstan.neon
@@ -1,5 +1,5 @@
 includes:
-  - %currentWorkingDirectory%/vendor/prestashop/php-dev-tools/phpstan/extension.neon
+  - %currentWorkingDirectory%/vendor/prestashop/php-dev-tools/phpstan/ps-module-extension.neon
     
 parameters:
   paths:


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      |  fix bad default in phpstan.neon
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     |  no
| Fixed ticket?     | Fixes #51 
| How to test?      | Please indicate how to best verify that this PR is correct.
| Possible impacts? | ? probably none, because I changed the template, not the filename.

This may help to test : (grabed from my history) (not retested) :
```shell
git clone https://github.com/PrestaShop/blockreassurance.git --depth 1
cd blockreassurance
composer install --dev
wget https://github.com/phpstan/phpstan/releases/download/0.12.83/phpstan.phar
chmod +x phpstan.phar
php vendor/bin/prestashop-coding-standards phpstan:init --dest ./
_PS_ROOT_DIR_=/home/http/tests/prestashop/ps1771 ./phpstan.phar analyse
```

