### PR TITLE
defines _THEME_NAME_ & __PS_BASE_URI__ early to avoid warnings.

### DIFF
--- a/phpstan/bootstrap.php
+++ b/phpstan/bootstrap.php
@@ -32,6 +32,8 @@ require_once realpath(__DIR__ . '/../../../autoload.php');
 // Add PrestaShop composer autoload
 define('_PS_ADMIN_DIR_', $rootDir . '/admin-dev/');
 define('PS_ADMIN_DIR', _PS_ADMIN_DIR_);
+define('__PS_BASE_URI__', '/');
+define('_THEME_NAME_', 'default-bootstrap');
 
 requireFileIfItExists($rootDir . '/tools/smarty/Smarty.class.php');
 requireFileIfItExists($rootDir . '/config/defines.inc.php');
@@ -117,16 +119,10 @@ $constantsToDefine = [
   '_PS_SSL_PORT_' => [
       'type' => 'int',
   ],
-  '_THEME_NAME_' => [
-      'type' => 'string',
-  ],
   '_THEME_COL_DIR_' => [
       'type' => 'string',
   ],
   '_PARENT_THEME_NAME_' => [
-      'type' => 'string',
-  ],
-  '__PS_BASE_URI__' => [
       'type' => 'string',
   ],
   '_PS_PRICE_DISPLAY_PRECISION_' => [


### PR DESCRIPTION
replacement for #54 (same but finished and rebase on fresh master branch).

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Avoid undefined constants : makes phpstan tests fail on CI
| Type?             | bug fix 
| BC breaks?        |  no
| Deprecations?     | no
| Fixed ticket?     | #53 
| How to test?      | run the analyse , ?(use php 7.4)
| Possible impacts? |  may hide problems inside Prestashop, but this is not to test Prestashop.


