### PR TITLE
Fix stub, ModuleCore can't return Module instance

### DIFF
--- a/phpstan/stubs/Module.stub
+++ b/phpstan/stubs/Module.stub
@@ -1,7 +1,7 @@
 <?php
 
 namespace PrestaShop\PrestaShop\Core\Module {
-    
+
     interface ModuleInterface
     {
     }
@@ -12,14 +12,14 @@ namespace {
     class Module extends ModuleCore
     {
     }
-    
+
     use PrestaShop\PrestaShop\Core\Module\ModuleInterface;
-    
+
     /**
      * Missing properties:
-     * @property string $module_key 
-     * @property bool $bootstrap 
-     * @property string $confirmUninstall 
+     * @property string $module_key
+     * @property bool $bootstrap
+     * @property string $confirmUninstall
      */
     abstract class ModuleCore implements ModuleInterface
     {
@@ -32,7 +32,7 @@ namespace {
          *
          * @param string $module_name Module name
          *
-         * @return Module|false
+         * @return self|false
          */
         public static function getInstanceByName($module_name) {}
     }


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Stubs files are no analyzed: https://phpstan.org/user-guide/stub-files#:~:text=Stub%20files%20are%20analysed%20independently,the%20problem%20of%20optional%20dependencies. And Abstract class can't return an instance of parent class because it's not defined yet.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
