### PR TITLE
Add autoindex lib to php-dev-tools (v3 branch)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Related packages:
 
 * [friendsofphp/php-cs-fixer](http://github.com/FriendsOfPHP/PHP-CS-Fixer)
 * [phpstan/phpstan](https://github.com/phpstan/phpstan)
+* [prestashop/autoindex](https://github.com/PrestaShopCorp/autoindex)
 * [prestashop/header-stamp](https://github.com/PrestaShopCorp/header-stamp)
 
 
@@ -64,6 +65,14 @@ Otherwise, you can specify the path to the PHPStan binary. For instance:
 
 ```php
 $ _PS_ROOT_DIR_=<Path_to_PrestaShop> php ~/.composer/vendor/bin/phpstan.phar --configuration=tests/phpstan/phpstan.neon analyse <path1 [path2 [...]]>
+```
+
+### Autoindex
+
+Applying an index.php file to all your project subfolders will be useful to avoid directories to be listed by the webserver.
+
+```php
+$ vendor/bin/autoindex
 ```
 
 ### Header Stamp

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
     "friendsofphp/php-cs-fixer": "^2.14",
     "squizlabs/php_codesniffer": "^3.4",
     "symfony/filesystem": "~3.2 || ~4.0 || ~5.0",
-    "prestashop/header-stamp": "^1.0"
+    "prestashop/header-stamp": "^1.0",
+    "prestashop/autoindex": "^1.0"
   },
   "conflict": {
     "friendsofphp/php-cs-fixer": "2.18.3"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d33354da7d15849d5dc1ea115352bd94",
+    "content-hash": "e832f1ed5a0ced9802600d1b48d2cb4c",
     "packages": [
         {
             "name": "composer/semver",
@@ -516,6 +516,52 @@
                 "diff"
             ],
             "time": "2020-10-14T08:39:05+00:00"
+        },
+        {
+            "name": "prestashop/autoindex",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PrestaShopCorp/autoindex.git",
+                "reference": "92e10242f94a99163dece280f6bd7b7c2b79c158"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PrestaShopCorp/autoindex/zipball/92e10242f94a99163dece280f6bd7b7c2b79c158",
+                "reference": "92e10242f94a99163dece280f6bd7b7c2b79c158",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^3.1",
+                "php": ">=5.6",
+                "symfony/console": "^3.4",
+                "symfony/finder": "^3.4"
+            },
+            "bin": [
+                "bin/autoindex"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PrestaShop\\AutoIndex\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "AFL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "PrestaShop SA",
+                    "email": "contact@prestashop.com"
+                }
+            ],
+            "description": "Automatically add an 'index.php' in all the current or specified directories and all sub-directories.",
+            "homepage": "https://github.com/PrestaShopCorp/autoindex",
+            "support": {
+                "source": "https://github.com/PrestaShopCorp/autoindex/tree/v1.0.0"
+            },
+            "time": "2020-03-11T13:37:03+00:00"
         },
         {
             "name": "prestashop/header-stamp",
@@ -1493,5 +1539,5 @@
     "platform-overrides": {
         "php": "5.6.0"
     },
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.1.0"
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add autoindex to php-dev-tools libraries. This library is useful for modules that need to avoid access to their folders.
| Type?             | new feature
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| How to test?      | /
| Possible impacts? | /