### PR TITLE
Remove php in front of vendor/bin/php-cs-fixer fix, since that is wrong

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ Running the tools can be done by calling its binary:
 
 ### PHP CS Fixer
 
-```php
-php vendor/bin/php-cs-fixer fix
+```bash
+$ vendor/bin/php-cs-fixer fix
 ```
 
 ### PHPStan


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Just a minor change in the `README.md` that had one error about `php-cs-fixer` being run with `php` in front, that is wrong.
| Type?             | bug fix 
| BC breaks?        |  no
| Deprecations?     |  no
| Fixed ticket?     | 
| How to test?      | Agree/disagree that that feature is now correctly documented
| Possible impacts? | none

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
