### PR TITLE
Add new rule to add visibility for only method and property inside a …

### DIFF
--- a/src/CsFixer/Config.php
+++ b/src/CsFixer/Config.php
@@ -31,6 +31,9 @@ class Config extends BaseConfig
                 'noise_remaining_usages_exclude' => [],
             ],
             'function_to_constant' => false,
+            'visibility_required' => [
+                'elements' => ['property', 'method'],
+            ],
             'no_alias_functions' => false,
             'phpdoc_summary' => false,
             'phpdoc_align' => [


### PR DESCRIPTION
…class

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Adding new rule for set visibility only for method and properties. We disabled this rule only for 'const' case
| Type?             |  improvement | bugfix
| BC breaks?        |  no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | Remove keyword public for method or property and run csfixer, he should add the missing keyword
| Possible impacts? | none

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
