### PR TITLE
Load bootstrap.php file with a relative path, removing an hardcoded path to the root vendor folder

### DIFF
--- a/phpstan/ps-module-extension.neon
+++ b/phpstan/ps-module-extension.neon
@@ -1,9 +1,10 @@
 parameters:
   bootstrapFiles:
-    - %currentWorkingDirectory%/vendor/prestashop/php-dev-tools/phpstan/bootstrap.php
+    - ./bootstrap.php
   stubFiles:
     - stubs/Module.stub
     - stubs/Tab.stub
   dynamicConstantNames:
     - _PS_VERSION_
     - _PS_MODE_DEV_
+    - _PS_MODE_DEMO_


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | This PR allows developer to load our configuration files from any folder, not only the vendor/ at the root of the module.
| Type?             | improvement
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | /
| How to test?      | No change for existing users, new ones can require the dependency a subfolder and still be able to call phpstan.