### PR TITLE
New bump-version command for bumping module version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Running the tools can be done by calling their respective binary:
 ### PHP CS Fixer
 
 Initialize the configuration with:
-```bash 
+```bash
 $ php vendor/bin/prestashop-coding-standards cs-fixer:init [--dest /path/to/my/project]
 ```
 
@@ -99,3 +99,17 @@ $ vendor/bin/header-stamp --license=assets/afl.txt --exclude=vendor,node_modules
 ```
 
 Available options are provided with `--help`.
+
+### Bump Module Version
+
+Bump your module version number using [Semantic Versioning](https://semver.org/) in preparation for new release.
+
+Updates module `$this->version` value in the module main php class file and `<version>` tag in `config.xml` file (if present).
+
+```bash
+$ php vendor/bin/prestashop-coding-standards bump-version patch    # 1.2.3 → 1.2.4
+$ php vendor/bin/prestashop-coding-standards bump-version minor    # 1.2.3 → 1.3.0
+$ php vendor/bin/prestashop-coding-standards bump-version major    # 1.2.3 → 2.0.0
+```
+
+The current version is read from the module main php file `$this->version` and bumped

--- a/bin/prestashop-coding-standards
+++ b/bin/prestashop-coding-standards
@@ -15,8 +15,10 @@ if (file_exists($autoloadFile)) {
 use Symfony\Component\Console\Application;
 use PrestaShop\CodingStandards\Command\CsFixerInitCommand;
 use PrestaShop\CodingStandards\Command\PhpStanInitCommand;
+use PrestaShop\CodingStandards\Command\BumpVersionCommand;
 
 $app = new Application();
 $app->add(new CsFixerInitCommand());
 $app->add(new PhpStanInitCommand());
+$app->add(new BumpVersionCommand());
 $app->run();

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,8 @@
   "require": {
     "php": ">=7.2.5",
     "symfony/console": "~3.2 || ~4.0 || ~5.0 || ~6.0 || ~7.0",
-    "symfony/filesystem": "~3.2 || ~4.0 || ~5.0 || ~6.0 || ~7.0"
+    "symfony/filesystem": "~3.2 || ~4.0 || ~5.0 || ~6.0 || ~7.0",
+    "composer/semver": "^3.0"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3.2"

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,85 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "027badef563e13f110734a95ed41fb10",
+    "content-hash": "08cb640f020e9d5d0e449ab951aa27a6",
     "packages": [
+        {
+            "name": "composer/semver",
+            "version": "3.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/semver.git",
+                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/semver/zipball/198166618906cb2de69b95d7d47e5fa8aa1b2b95",
+                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.11",
+                "symfony/phpunit-bridge": "^3 || ^7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Semver\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "Semver library that offers utilities, version constraint parsing and validation.",
+            "keywords": [
+                "semantic",
+                "semver",
+                "validation",
+                "versioning"
+            ],
+            "support": {
+                "irc": "ircs://irc.libera.chat:6697/composer",
+                "issues": "https://github.com/composer/semver/issues",
+                "source": "https://github.com/composer/semver/tree/3.4.4"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-20T19:15:30+00:00"
+        },
         {
             "name": "psr/container",
             "version": "1.1.1",
@@ -1064,87 +1141,6 @@
             "time": "2022-01-21T20:24:37+00:00"
         },
         {
-            "name": "composer/semver",
-            "version": "3.4.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/composer/semver.git",
-                "reference": "35e8d0af4486141bc745f23a29cc2091eb624a32"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/35e8d0af4486141bc745f23a29cc2091eb624a32",
-                "reference": "35e8d0af4486141bc745f23a29cc2091eb624a32",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3.2 || ^7.0 || ^8.0"
-            },
-            "require-dev": {
-                "phpstan/phpstan": "^1.4",
-                "symfony/phpunit-bridge": "^4.2 || ^5"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "3.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Composer\\Semver\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nils Adermann",
-                    "email": "naderman@naderman.de",
-                    "homepage": "http://www.naderman.de"
-                },
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be",
-                    "homepage": "http://seld.be"
-                },
-                {
-                    "name": "Rob Bast",
-                    "email": "rob.bast@gmail.com",
-                    "homepage": "http://robbast.nl"
-                }
-            ],
-            "description": "Semver library that offers utilities, version constraint parsing and validation.",
-            "keywords": [
-                "semantic",
-                "semver",
-                "validation",
-                "versioning"
-            ],
-            "support": {
-                "irc": "ircs://irc.libera.chat:6697/composer",
-                "issues": "https://github.com/composer/semver/issues",
-                "source": "https://github.com/composer/semver/tree/3.4.0"
-            },
-            "funding": [
-                {
-                    "url": "https://packagist.com",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/composer",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-08-31T09:50:34+00:00"
-        },
-        {
             "name": "composer/xdebug-handler",
             "version": "2.0.5",
             "source": {
@@ -2139,13 +2135,13 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": ">=7.2.5"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "7.2.5"
     },

--- a/src/Command/BumpVersionCommand.php
+++ b/src/Command/BumpVersionCommand.php
@@ -1,0 +1,235 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PrestaShop\CodingStandards\Command;
+
+use Composer\Semver\VersionParser;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Filesystem\Filesystem;
+
+class BumpVersionCommand extends AbstractCommand
+{
+
+    const SEMVER_TYPES = ['patch', 'minor', 'major'];
+
+    protected function configure(): void
+    {
+        $this->setName('bump-version')
+            ->setDescription('Bump the version number')
+            ->addArgument(
+                'type',
+                InputArgument::REQUIRED,
+                'Version bump type: ' . implode(', ', self::SEMVER_TYPES)
+            )
+            ->addOption(
+                'path',
+                'p',
+                InputOption::VALUE_REQUIRED,
+                'Path to the module directory',
+                '.'
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $type = $input->getArgument('type');
+        $modulePath = $input->getOption('path');
+
+        if (!in_array($type, self::SEMVER_TYPES)) {
+            $output->writeln('<error>Invalid version type. Valid values are: ' . implode(', ', self::SEMVER_TYPES) . '</error>');
+            return self::INVALID;
+        }
+
+        // Check that we can find the main module file
+        $mainModuleFile = $this->findMainModuleFile($modulePath);
+        if (!$mainModuleFile) {
+            $output->writeln('<error>Could not find main module file</error>');
+            return self::FAILURE;
+        }
+
+        // Get current version from the module file
+        $currentVersion = $this->getCurrentVersion($mainModuleFile);
+        if (!$currentVersion) {
+            $output->writeln('<error>Could not find current version in module file</error>');
+            return self::FAILURE;
+        }
+
+        // Strip to core version (major.minor.patch) if needed
+        $originalVersion = $currentVersion;
+        if (preg_match('/^(\d+\.\d+\.\d+)/', $currentVersion, $matches)) {
+            $currentVersion = $matches[1];
+            if ($currentVersion !== $originalVersion) {
+                $output->writeln(sprintf('<comment>Stripped version from %s to %s</comment>', $originalVersion, $currentVersion));
+            }
+        }
+
+        // Validate using composer/semver
+        $parser = new VersionParser();
+        try {
+            $parser->normalize($currentVersion);
+        } catch (\UnexpectedValueException $e) {
+            $output->writeln(sprintf('<error>Invalid semantic version in module: %s</error>', $currentVersion));
+            $output->writeln(sprintf('<error>%s</error>', $e->getMessage()));
+            return self::FAILURE;
+        }
+
+        $output->writeln(sprintf('<info>Current version: %s</info>', $currentVersion));
+
+        // Bump the version
+        $newVersion = $this->bumpVersion($currentVersion, $type);
+        $output->writeln(sprintf('<info>New version: %s</info>', $newVersion));
+
+        // Update module PHP file
+        $this->updateModuleFile($mainModuleFile, $currentVersion, $newVersion);
+        $output->writeln(sprintf('<info>Updated %s</info>', basename($mainModuleFile)));
+
+        // Update config.xml if it exists
+        $configFile = dirname($mainModuleFile) . '/config.xml';
+        if (file_exists($configFile)) {
+            $configVersion = $this->getConfigVersion($configFile);
+            if ($configVersion && $configVersion !== $currentVersion) {
+                $output->writeln(sprintf('<comment>Warning: config.xml version (%s) differs from module version (%s)</comment>', $configVersion, $currentVersion));
+                // Force update by using the old version
+                $this->updateConfigFile($configFile, $configVersion, $newVersion);
+            } else {
+                // Versions match, update normally
+                $this->updateConfigFile($configFile, $currentVersion, $newVersion);
+            }
+            $output->writeln('<info>Updated config.xml</info>');
+        } else {
+            $output->writeln('<comment>config.xml not found, skipping</comment>');
+        }
+
+        $output->writeln(sprintf('<info>Successfully bumped version from %s to %s</info>', $currentVersion, $newVersion));
+
+        return self::SUCCESS;
+    }
+
+    private function findMainModuleFile(string $path): ?string
+    {
+        $fs = new Filesystem();
+
+        // Look for PHP files in the directory that match the directory name
+        $dirName = basename(realpath($path));
+        $possibleFile = $path . '/' . $dirName . '.php';
+
+        if ($fs->exists($possibleFile)) {
+            return $possibleFile;
+        }
+
+        // If not found, look for any PHP file that extends Module class
+        $files = glob($path . '/*.php');
+        foreach ($files as $file) {
+            try {
+                $content = file_get_contents($file);
+                if (preg_match('/class\s+\w+\s+extends\s+Module/i', $content)) {
+                    return $file;
+                }
+            } catch (\Exception $e) {
+                // Skip files that can't be read
+                continue;
+            }
+        }
+
+        return null;
+    }
+
+    private function getCurrentVersion(string $filePath): ?string
+    {
+        try {
+            $content = file_get_contents($filePath);
+        } catch (\Exception $e) {
+            return null;
+        }
+
+        // Extract whatever is in $this->version = '...'
+        if (preg_match('/\$this->version\s*=\s*[\'"]([^\'"]+)[\'"]/', $content, $matches)) {
+            return trim($matches[1]);
+        }
+
+        return null;
+    }
+
+    private function getConfigVersion(string $filePath): ?string
+    {
+        try {
+            $content = file_get_contents($filePath);
+        } catch (\Exception $e) {
+            return null;
+        }
+
+        // Extract version from <version>...</version> or <version><![CDATA[...]]></version>
+        if (preg_match('/<version>(?:<!\[CDATA\[)?([^\]<]+)(?:\]\]>)?<\/version>/', $content, $matches)) {
+            return trim($matches[1]);
+        }
+
+        return null;
+    }
+
+    private function bumpVersion(string $version, string $type): string
+    {
+        // Parse version components (already validated by normalize())
+        list($major, $minor, $patch) = explode('.', $version);
+        $major = (int)$major;
+        $minor = (int)$minor;
+        $patch = (int)$patch;
+
+        // Apply semver bump
+        switch ($type) {
+            case 'major':
+                $major++;
+                $minor = 0;
+                $patch = 0;
+                break;
+            case 'minor':
+                $minor++;
+                $patch = 0;
+                break;
+            case 'patch':
+                $patch++;
+                break;
+        }
+
+        return sprintf('%d.%d.%d', $major, $minor, $patch);
+    }
+
+    private function updateModuleFile(string $filePath, string $oldVersion, string $newVersion): void
+    {
+        try {
+            $content = file_get_contents($filePath);
+
+            // Update $this->version
+            $content = preg_replace(
+                '/(\$this->version\s*=\s*[\'"])' . preg_quote($oldVersion, '/') . '([\'"])/i',
+                '${1}' . $newVersion . '${2}',
+                $content
+            );
+
+            file_put_contents($filePath, $content);
+        } catch (\Exception $e) {
+            throw new \RuntimeException(sprintf('Failed to update module file: %s', $e->getMessage()), 0, $e);
+        }
+    }
+
+    private function updateConfigFile(string $filePath, string $oldVersion, string $newVersion): void
+    {
+        try {
+            $content = file_get_contents($filePath);
+
+            // Update <version>x.x.x</version> or <version><![CDATA[x.x.x]]></version>
+            $content = preg_replace(
+                '/<version>(<!\[CDATA\[)?' . preg_quote($oldVersion, '/') . '(\]\]>)?<\/version>/i',
+                '<version>${1}' . $newVersion . '${2}</version>',
+                $content
+            );
+
+            file_put_contents($filePath, $content);
+        } catch (\Exception $e) {
+            throw new \RuntimeException(sprintf('Failed to update config file: %s', $e->getMessage()), 0, $e);
+        }
+    }
+}

--- a/tests/modules_samples/constant_check/config.xml
+++ b/tests/modules_samples/constant_check/config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module>
+    <name>constant_check</name>
+    <displayName><![CDATA[Constant Check]]></displayName>
+    <version><![CDATA[1.0.0]]></version>
+    <description><![CDATA[Test module for constant checking]]></description>
+    <author><![CDATA[PrestaShopCorp]]></author>
+    <tab><![CDATA[advertising_marketing]]></tab>
+</module>

--- a/tests/test-bump-version.sh
+++ b/tests/test-bump-version.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+
+# Test script for bump-version command
+# This script tests the version bumping functionality using the constant_check module
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo "=========================================="
+echo "Testing bump-version command"
+echo "=========================================="
+
+# Get absolute path to the binary
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BIN_PATH="${SCRIPT_DIR}/../bin/prestashop-coding-standards"
+
+# Create temporary test directory
+TEST_DIR="$(mktemp -d)"
+echo -e "${YELLOW}Creating test directory: ${TEST_DIR}${NC}"
+
+# Copy the constant_check module to temp directory
+cp -r modules_samples/constant_check "${TEST_DIR}/"
+cd "${TEST_DIR}/constant_check"
+
+# Function to get version from PHP file
+get_php_version() {
+    grep -oP "\\\$this->version = '\K[^']+" constant_check.php
+}
+
+# Function to get version from config.xml
+get_xml_version() {
+    grep -oP '<version><!\[CDATA\[\K[^\]]+' config.xml
+}
+
+# Function to run bump-version command
+bump_version() {
+    php "${BIN_PATH}" bump-version "$1" --path .
+}
+
+echo ""
+echo "Initial state:"
+PHP_VERSION=$(get_php_version)
+XML_VERSION=$(get_xml_version)
+echo "  PHP version: ${PHP_VERSION}"
+echo "  XML version: ${XML_VERSION}"
+
+if [ "${PHP_VERSION}" != "1.0.0" ] || [ "${XML_VERSION}" != "1.0.0" ]; then
+    echo -e "${RED}ERROR: Initial version should be 1.0.0${NC}"
+    exit 1
+fi
+
+# Test 1: Bump patch version
+echo ""
+echo -e "${YELLOW}Test 1: Bumping patch version (1.0.0 -> 1.0.1)${NC}"
+bump_version patch
+
+PHP_VERSION=$(get_php_version)
+XML_VERSION=$(get_xml_version)
+echo "  PHP version: ${PHP_VERSION}"
+echo "  XML version: ${XML_VERSION}"
+
+if [ "${PHP_VERSION}" != "1.0.1" ] || [ "${XML_VERSION}" != "1.0.1" ]; then
+    echo -e "${RED}FAIL: Expected 1.0.1, got PHP: ${PHP_VERSION}, XML: ${XML_VERSION}${NC}"
+    exit 1
+fi
+echo -e "${GREEN}PASS${NC}"
+
+# Test 2: Bump patch again
+echo ""
+echo -e "${YELLOW}Test 2: Bumping patch version again (1.0.1 -> 1.0.2)${NC}"
+bump_version patch
+
+PHP_VERSION=$(get_php_version)
+XML_VERSION=$(get_xml_version)
+echo "  PHP version: ${PHP_VERSION}"
+echo "  XML version: ${XML_VERSION}"
+
+if [ "${PHP_VERSION}" != "1.0.2" ] || [ "${XML_VERSION}" != "1.0.2" ]; then
+    echo -e "${RED}FAIL: Expected 1.0.2, got PHP: ${PHP_VERSION}, XML: ${XML_VERSION}${NC}"
+    exit 1
+fi
+echo -e "${GREEN}PASS${NC}"
+
+# Test 3: Bump minor version
+echo ""
+echo -e "${YELLOW}Test 3: Bumping minor version (1.0.2 -> 1.1.0)${NC}"
+bump_version minor
+
+PHP_VERSION=$(get_php_version)
+XML_VERSION=$(get_xml_version)
+echo "  PHP version: ${PHP_VERSION}"
+echo "  XML version: ${XML_VERSION}"
+
+if [ "${PHP_VERSION}" != "1.1.0" ] || [ "${XML_VERSION}" != "1.1.0" ]; then
+    echo -e "${RED}FAIL: Expected 1.1.0, got PHP: ${PHP_VERSION}, XML: ${XML_VERSION}${NC}"
+    exit 1
+fi
+echo -e "${GREEN}PASS${NC}"
+
+# Test 4: Bump major version
+echo ""
+echo -e "${YELLOW}Test 4: Bumping major version (1.1.0 -> 2.0.0)${NC}"
+bump_version major
+
+PHP_VERSION=$(get_php_version)
+XML_VERSION=$(get_xml_version)
+echo "  PHP version: ${PHP_VERSION}"
+echo "  XML version: ${XML_VERSION}"
+
+if [ "${PHP_VERSION}" != "2.0.0" ] || [ "${XML_VERSION}" != "2.0.0" ]; then
+    echo -e "${RED}FAIL: Expected 2.0.0, got PHP: ${PHP_VERSION}, XML: ${XML_VERSION}${NC}"
+    exit 1
+fi
+echo -e "${GREEN}PASS${NC}"
+
+# Test 5: Multiple minor bumps
+echo ""
+echo -e "${YELLOW}Test 5: Multiple minor bumps (2.0.0 -> 2.1.0 -> 2.2.0)${NC}"
+bump_version minor
+PHP_VERSION=$(get_php_version)
+if [ "${PHP_VERSION}" != "2.1.0" ]; then
+    echo -e "${RED}FAIL: Expected 2.1.0, got ${PHP_VERSION}${NC}"
+    exit 1
+fi
+
+bump_version minor
+PHP_VERSION=$(get_php_version)
+XML_VERSION=$(get_xml_version)
+echo "  PHP version: ${PHP_VERSION}"
+echo "  XML version: ${XML_VERSION}"
+
+if [ "${PHP_VERSION}" != "2.2.0" ] || [ "${XML_VERSION}" != "2.2.0" ]; then
+    echo -e "${RED}FAIL: Expected 2.2.0, got PHP: ${PHP_VERSION}, XML: ${XML_VERSION}${NC}"
+    exit 1
+fi
+echo -e "${GREEN}PASS${NC}"
+
+# Cleanup
+echo ""
+echo -e "${YELLOW}Cleaning up test directory${NC}"
+rm -rf "${TEST_DIR}"
+
+echo ""
+echo "=========================================="
+echo -e "${GREEN}All tests passed successfully!${NC}"
+echo "=========================================="


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | New `bump-version` command to bump module version number in semver format. 
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | -
| Sponsor company   | 
| How to test?      | Take an existing module and install this branch as a dev requirement for the module. Run `vendor/bin/prestashop-coding-standards bump-version patch` and check that the module $this->version and xml version tag were updated to next patch version.
