### PR TITLE
Replace deprecated visibility_required rule with modifier_keywords

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "symfony/filesystem": "~3.2 || ~4.0 || ~5.0 || ~6.0 || ~7.0"
   },
   "require-dev": {
-    "friendsofphp/php-cs-fixer": "^3.2"
+    "friendsofphp/php-cs-fixer": "^3.95"
   },
   "suggest": {
     "prestashop/header-stamp": "^2.0",

--- a/src/CsFixer/Config.php
+++ b/src/CsFixer/Config.php
@@ -31,7 +31,7 @@ class Config extends BaseConfig
                 'noise_remaining_usages_exclude' => [],
             ],
             'function_to_constant' => false,
-            'visibility_required' => [
+            'modifier_keywords' => [
                 'elements' => ['property', 'method'],
             ],
             'no_alias_functions' => false,


### PR DESCRIPTION
PHP-CS-Fixer 3.95+ emits a deprecation warning on every run using this preset:

      Detected deprecations in use (they will stop working in next major
      release):
      - Rule "visibility_required" is deprecated. Use "modifier_keywords" instead.

  The `visibility_required` fixer is now a deprecated proxy for `modifier_keywords`, which is a superset that also covers `final`, `abstract`, `readonly` and `static` keywords. 
  Using the same `'elements' => ['property', 'method']` configuration keeps the behaviour strictly identical to the legacy rule.

  Bumps the `friendsofphp/php-cs-fixer` require-dev constraint to `^3.95` since `modifier_keywords` was introduced in that release.

  | Questions         | Answers
  | ------------------| -------------------------------------------------------
  | Description?      | Rename the deprecated `visibility_required` rule to its successor `modifier_keywords` in the PrestaShop coding-standards preset, and bump the `friendsofphp/php-cs-fixer` dev dependency to `^3.95` (the release that introduced the new rule). Silences the deprecation warning emitted on every run by every downstream module using this preset, and makes the preset forward-compatible with the upcoming PHP-CS-Fixer v4 where the legacy alias will be removed.
  | Type?             | bug fix
  | BC breaks?        | no
  | Deprecations?     | no
  | Fixed ticket?     | n/a
  | Sponsor company   | n/a
  | How to test?      | 1. Check out this branch. 2. `composer install`. 3. Run `./vendor/bin/php-cs-fixer fix --dry-run --config=<(echo '<?php return (new \PrestaShop\CodingStandards\CsFixer\Config())->setFinder(PhpCsFixer\Finder::create()->in(__DIR__ . "/src"));')` on any PHP file — the deprecation warning no longer appears. Applying the preset to a file with `public  function foo()` (double space) still flags it, confirming `modifier_keywords` enforces the same fix as the old rule.